### PR TITLE
FindPyUblas.cmake: fix Python executable.

### DIFF
--- a/CMakeModules/FindPyUblas.cmake
+++ b/CMakeModules/FindPyUblas.cmake
@@ -1,6 +1,6 @@
 # try to find the pyublas library
 
-execute_process ( COMMAND python -c "import pyublas; print(pyublas.__path__[0])" OUTPUT_VARIABLE PYUBLAS_OUT OUTPUT_STRIP_TRAILING_WHITESPACE)
+execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "import pyublas; print(pyublas.__path__[0])" OUTPUT_VARIABLE PYUBLAS_OUT OUTPUT_STRIP_TRAILING_WHITESPACE)
 
 find_path(PYUBLAS_INCLUDE_DIR pyublas/numpy.hpp
           HINTS ${PYUBLAS_OUT}/../include ${PYUBLAS_OUT}/include /usr/local/include /usr/include)

--- a/src/cuv_python/CMakeLists.txt
+++ b/src/cuv_python/CMakeLists.txt
@@ -89,7 +89,7 @@ endif()
 SET(PYTHON_VERSION_MAJOR_MINOR ${PYTHON_VERSION_MAJOR_MINOR} CACHE STRING "Python version used")
 SET(_PYTHON_PACKAGES_PATH ${_PYTHON_PACKAGES_PATH} CACHE PATH "Where to install python module to")
 
-#execute_process ( COMMAND python -c "from distutils.sysconfig import get_python_lib; print get_python_lib()" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
+#execute_process ( COMMAND ${PYTHON_EXECUTABLE} -c "from distutils.sysconfig import get_python_lib; print get_python_lib()" OUTPUT_VARIABLE PYTHON_SITE_PACKAGES OUTPUT_STRIP_TRAILING_WHITESPACE)
 install(TARGETS cuv_python  DESTINATION ${_PYTHON_PACKAGES_PATH}/cuv_python${LIB_SUFFIX})
 install(FILES   __init__.py DESTINATION ${_PYTHON_PACKAGES_PATH}/cuv_python${LIB_SUFFIX})
 

--- a/src/tests/CMakeLists.txt
+++ b/src/tests/CMakeLists.txt
@@ -89,7 +89,7 @@ endif(PYTHONLIBS_FOUND )
 
 IF(CUV_PYTHON_BINDINGS)
 	SET(ENV{PYTHONPATH} ${CMAKE_BINARY_DIR}/python_bindings )
-	ADD_TEST( load_py sh -c "PYTHONPATH=${CMAKE_BINARY_DIR}/src python -c 'import cuv_python as cp'" )
+	ADD_TEST( load_py sh -c "PYTHONPATH=${CMAKE_BINARY_DIR}/src ${PYTHON_EXECUTABLE} -c 'import cuv_python as cp'" )
 
 	FIND_PROGRAM(NOSETEST_EXECUTABLE nosetests)
 	IF(NOSETEST_EXECUTABLE)


### PR DESCRIPTION
Since Python 3 is the default Python version on some distributions (e.g. Arch Linux), we need to use the CMake variable storing the actual Python executable. Then, to use Python 2, since CMake often mixes up Python 2/3 libraries (even if Python 2 is set in `CMakeLists.txt`):

``` sh
cmake .. -DPYTHON_EXECUTABLE=/usr/bin/python2 \
         -DPYTHON_INCLUDE_DIR=/usr/include/python2.7 \
         -DPYTHON_LIBRARY=/usr/lib/libpython2.7.so
```
